### PR TITLE
Fix empty HTML anchor tags showing as visible text

### DIFF
--- a/src/muya/lib/parser/render/renderInlines/htmlTag.js
+++ b/src/muya/lib/parser/render/renderInlines/htmlTag.js
@@ -4,9 +4,10 @@ import sanitize, { isValidAttribute } from '../../../utils/dompurify'
 
 export default function htmlTag(h, cursor, block, token, outerClass) {
   const { tag, openTag, closeTag, children, attrs } = token
-  const className = children
-    ? this.getClassName(outerClass, block, token, cursor)
-    : CLASS_OR_ID.AG_GRAY
+  // Always use getClassName to properly handle visibility based on cursor position.
+  // Previously, empty HTML tags (like <a name="anchor"></a>) were forced to AG_GRAY,
+  // making them always visible as gray text instead of being hidden when not focused.
+  const className = this.getClassName(outerClass, block, token, cursor)
   const tagClassName = className === CLASS_OR_ID.AG_HIDE ? className : CLASS_OR_ID.AG_HTML_TAG
   const { start, end } = token.range
   const openContent = this.highlight(h, block, start, start + openTag.length, token)


### PR DESCRIPTION
## Problem

Empty HTML tags like `<a name="anchor"></a>` were always rendered with `AG_GRAY` class, making them appear as visible gray text regardless of cursor position.

## Root Cause

In `htmlTag.js`, the className assignment bypassed `getClassName()` for tags without children:

```javascript
const className = children
  ? this.getClassName(outerClass, block, token, cursor)
  : CLASS_OR_ID.AG_GRAY  // ← Always visible for empty tags
```

## Solution

Remove the conditional and always use `getClassName()`, which properly handles visibility based on cursor position (hidden when not focused, visible when editing nearby):

```javascript
const className = this.getClassName(outerClass, block, token, cursor)
```

## Testing

- Empty anchor tags like `<a name="section"></a>` now hide when cursor is elsewhere
- Tags become visible when cursor is within or adjacent to them
- No impact on non-empty HTML tags which continue to work as before

---

*Rebased from `claude/fix-marktext-anchor-tags-j7eI2` onto current master for a clean diff.*